### PR TITLE
Исправляем тесты

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -227,7 +227,7 @@ class DzrBot(Bot):
 
         server_message = parse_result.get('message', '').lower()
         if server_message:
-            self.sendMessage(chat_id, "{emoji}{new_level}{code} {server_message}{clock}".format(
+            self.sendMessage(chat_id, "{emoji}{new_level}{code} : {server_message}.{clock}".format(
                 emoji='✅ ' if 'код принят' in server_message else '',
                 new_level='💥 ' if 'выполняйте следующее задание' in server_message else '',
                 clock=" Таймер: {}".format(clock) if clock else '',


### PR DESCRIPTION
Исправил в `bot.py` шаблон сообщения (в тестах он гламурнее).

Добавил вспомогательную функцию для генерации "входящего" сообщения в `test_bot.py`, чтобы не писать ручками `'date': time.time()` в 100500 местах.

Внезапно, добавил тест на проходящий кодик (что эмодзик рисуется), а то его не было.

И проверку, что после попытки установить неправильный sleep_seconds ничего внутри не сбрасывается.