### PR TITLE
Определение номера метки

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -226,13 +226,25 @@ class DzrBot(Bot):
         clock = parse_result.get('clock')
 
         server_message = parse_result.get('message', '').lower()
+        code_ok = 'код принят' in server_message
+
+        metki_message = ""
+        if code_ok and parse_result.get('new_metki'):
+            messages = ["Сектор {sector_id}, метка {metka}".format(**metka)
+                        for metka in parse_result['new_metki']]
+            if len(messages) == 1:
+                metki_message = " " + messages[0] + "."
+            elif len(messages) <= 3:
+                metki_message = " " + " или ".join(messages) + "."
+
         if server_message:
-            self.sendMessage(chat_id, "{emoji}{new_level}{code} : {server_message}.{clock}".format(
-                emoji='✅ ' if 'код принят' in server_message else '',
+            self.sendMessage(chat_id, "{emoji}{new_level}{code} : {server_message}.{metki_message}{clock}".format(
+                emoji='✅ ' if code_ok else '',
                 new_level='💥 ' if 'выполняйте следующее задание' in server_message else '',
                 clock=" Таймер: {}".format(clock) if clock else '',
                 code=code,
                 server_message=server_message,
+                metki_message=metki_message,
             ), reply_to_message_id=message_id)
 
         self.parse_and_send(parse_result)

--- a/parser.py
+++ b/parser.py
@@ -173,7 +173,7 @@ class Parser(object):
 
         bot_data = self.table_bot.find_one(**{'token': settings.TOKEN})
 
-        if bot_data.get('level') != level:
+        if bot_data.get('level') is None or int(bot_data.get('level')) != level:
             self.table_bot.upsert({
                 'token': settings.TOKEN,
                 'level': level,

--- a/parser.py
+++ b/parser.py
@@ -155,6 +155,7 @@ class Parser(object):
         result = {
             'new_level': False,  # Новый уровень?
             'new_code': False,  # Новый пробитый код?
+            'new_metki': [],  # Номер (или возможные номера) пробитых кодов, если есть
             'sector_list': [],  # Инфо о взятых кодах
         }
         try:
@@ -221,6 +222,7 @@ class Parser(object):
                     if 'бонусные коды' not in sector['name']:
                         result['new_code'] = True
                     sector['code_list'].append(filters)
+                    result['new_metki'].append(filters)
 
             result['sector_list'].append(sector)
             self.table_sector.upsert({

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -104,6 +104,30 @@ class BotTestCase(TestCase):
         Если код верный, то бот должен послать об этом сообщение в чат
         """
         self.set_html('pages/code_1.html')
+        self.parser.parse()
+        self.set_html('pages/code_2.html')
+        self.parser._parse_message = Mock(return_value={'message': 'код принят. ищите следующий составной код'})
+        self.bot.on_chat_message(self._new_message_dict('dr4', message_id=321))
+        self.bot.sendMessage.assert_any_call('CHAT_ID', '✅ dr4 : код принят. ищите следующий составной код. Сектор 1, метка 8. Таймер: 01:27', reply_to_message_id=321)
+
+    def test_code_pass_unsure(self):
+        """
+        Вызываем пробитие кода (dr4), но возможны две метки.
+        """
+        self.set_html('pages/code_1.html')
+        self.parser.parse()
+        self.set_html('pages/code_3.html')
+        self.parser._parse_message = Mock(return_value={'message': 'код принят. ищите следующий составной код'})
+        self.bot.on_chat_message(self._new_message_dict('dr4', message_id=321))
+        self.bot.sendMessage.assert_any_call('CHAT_ID', '✅ dr4 : код принят. ищите следующий составной код. Сектор 1, метка 8 или Сектор 1, метка 11. Таймер: 01:27', reply_to_message_id=321)
+
+    def test_code_pass_unsure2(self):
+        """
+        Вызываем пробитие кода (dr4), но не ясно, по какой метке.
+        """
+        self.set_html('pages/code_1.html')
+        self.parser.parse()
+        self.set_html('pages/code_1.html')
         self.parser._parse_message = Mock(return_value={'message': 'код принят. ищите следующий составной код'})
         self.bot.on_chat_message(self._new_message_dict('dr4', message_id=321))
         self.bot.sendMessage.assert_any_call('CHAT_ID', '✅ dr4 : код принят. ищите следующий составной код. Таймер: 01:27', reply_to_message_id=321)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -141,6 +141,15 @@ class BotTestCase(TestCase):
         self.bot.handle_loop()
         self.bot.sendMessage.assert_any_call('CHANNEL_ID', 'Открыт спойлер')
 
+    def test_nothing_new(self):
+        """Если ничего не произошло, то ничего и не шлём"""
+        self.set_html('pages/code_1.html')
+        self.parser.parse()
+        self.bot.sendMessage.reset_mock()
+        self.set_html('pages/code_1.html')
+        self.bot.handle_loop()
+        self.assertFalse(self.bot.sendMessage.called)
+
     def test_new_code(self):
         """
         Если в движке появился новый пробитый код,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -14,6 +14,7 @@ class ParserTestCase(unittest.TestCase):
 
     def tearDown(self):
         """Очищаем таблицы после прохождения каждого теста"""
+        self.parser.table_bot.delete()
         self.parser.table_tip.delete()
         self.parser.table_code.delete()
         self.parser.table_sector.delete()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -54,6 +54,35 @@ class ParserTestCase(unittest.TestCase):
         self.assertEqual(code_2['ko'], '2')
         self.assertEqual(code_2['taken'], False)
 
+    def test_new_metki(self):
+        self.set_html('pages/code_1.html')
+        result = self.parser.parse()
+        self.assertEqual(len(result['new_metki']), 0)
+        self.set_html('pages/code_2.html')
+        result = self.parser.parse()
+        self.assertEqual(len(result['new_metki']), 1)
+        new_codes = [(m['sector_id'], m['metka']) for m in result['new_metki']]
+        self.assertIn((1, 8), new_codes)
+
+    def test_new_metki_multiple(self):
+        self.set_html('pages/code_1.html')
+        result = self.parser.parse()
+        self.assertEqual(len(result['new_metki']), 0)
+        self.set_html('pages/code_3.html')
+        result = self.parser.parse()
+        self.assertEqual(len(result['new_metki']), 2)
+        new_codes = [(m['sector_id'], m['metka']) for m in result['new_metki']]
+        self.assertIn((1, 8), new_codes)
+        self.assertIn((1, 11), new_codes)
+
+    def test_new_metki_no(self):
+        self.set_html('pages/code_1.html')
+        result = self.parser.parse()
+        self.assertEqual(len(result['new_metki']), 0)
+        self.set_html('pages/code_1.html')
+        result = self.parser.parse()
+        self.assertEqual(len(result['new_metki']), 0)
+
     def test_parse_tip(self):
         self.set_html('pages/tip_1.html')
         result = self.parser.parse()


### PR DESCRIPTION
1. Пофиксил (м.б. только у меня появляющуюся) багу, когда номер уровня в базе хранится строкой (для тестов я использовал sqlite, а не постгру), и парсер всегда считал, что уровень новый (`'19' != 19`).

2. В парсер впилил возврат ещё одного массива (`new_metki`), в котором содержится список меток, взятых с момента прошлого парсинга.

3. Если после пробитии кода закрасились новые метки (причём не слишком дохера, на случай лагов и параллельного ручного пробития), то в сообщение добавляем их номер(а).