### PR TITLE
Fix bug with wrong KO order when printing table

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -359,7 +359,9 @@ class DzrBot(Bot):
 
     def send_ko(self, channel_id):
         for sector in self.parser.table_sector.all():
-            sector['code_list'] = list(self.parser.table_code.find(sector_id=sector['id']))
+            code_list = list(self.parser.table_code.find(sector_id=sector['id']))
+            code_list.sort(key=lambda k: k['metka'])
+            sector['code_list'] = code_list
             self.sendMessage(channel_id, sector_text(sector), parse_mode='Markdown')
 
     def send_ko_img(self, channel_id):


### PR DESCRIPTION
Где-то когда-то у нас что-то поломалось (м.б. это связано с Postgres 10, м.б. с чем-то ещё), и порядок КО в табличке (в канале и по `/ko`) рандомно менялся. Тут мы явно сортируем по метке.